### PR TITLE
Update pins_RAMBO_THINKERV2.h

### DIFF
--- a/Marlin/src/pins/rambo/pins_RAMBO_THINKERV2.h
+++ b/Marlin/src/pins/rambo/pins_RAMBO_THINKERV2.h
@@ -34,13 +34,21 @@
   #define FIL_RUNOUT_PIN                      10
 #endif
 
-#if HAS_WIRED_LCD || TOUCH_UI_ULTIPANEL
-  #if ENABLED(ULTIPANEL) || TOUCH_UI_ULTIPANEL
-    #if NONE(VIKI2, miniVIKI)
-      #define BTN_EN1                         64
-      #define BTN_EN2                         63
-    #endif
-  #endif
+// support bltouch and fixed probes
+#if ENABLED(BLTOUCH)
+  #define Z_MIN_PIN    22
+#elif ENABLED(FIX_MOUNTED_PROBE)
+  #define Z_MIN_PIN    4 //24
+#else
+  #define Z_MIN_PIN    10
 #endif
+
+// Eryone has the fan pins reversed
+#define FAN1_PIN       2
+#define FAN2_PIN       6
+
+// set the encoder pins
+#define BTN_EN1                         64
+#define BTN_EN2                         63
 
 #include "pins_RAMBO.h"


### PR DESCRIPTION
include BLTouch and fixed probe support
reverse fan pins, according to Eryone's config
fix broken encoder knob